### PR TITLE
Add mcp url input inside gui

### DIFF
--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -67,6 +67,7 @@ with st.sidebar:
     if use_mcp:
         url = st.text_input("MCP URL", "http://127.0.0.1:8000/mcp")
         settings.mcp_url = url
+        os.environ["MCP_URL"] = url
     
     st.divider()
     

--- a/{{project_name}}/app/gui.py
+++ b/{{project_name}}/app/gui.py
@@ -65,7 +65,8 @@ with st.sidebar:
     )
     
     if use_mcp:
-        st.info(f"MCP URL: {settings.mcp_url}")
+        url = st.text_input("MCP URL", "http://127.0.0.1:8000/mcp")
+        settings.mcp_url = url
     
     st.divider()
     


### PR DESCRIPTION
Add text input for mcp url inside the streamlit gui for the agent, so it doesn't have to be changed in the config with rerunning the gui
<img width="254" height="678" alt="image" src="https://github.com/user-attachments/assets/72b8be29-a440-45f5-980f-e2ee0a0a9474" />
