### PR TITLE
Make template tasks cross-platform

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -94,10 +94,11 @@ _exclude:
   - "{{ '*/app/mcp' if project_type != 'mcp-server' else '' }}"
 
 _tasks:
-  - command: mv {{project_name}}/README_{{project_type}}.md {{project_name}}/README.md
+  - command: uv run python -c "import shutil; shutil.move('{{project_name}}/README_{{project_type}}.md', '{{project_name}}/README.md')"
     when: "{{ project_type in ['agent', 'mcp-server'] }}"
-  - command: mv {{project_name}}/README_api.md {{project_name}}/README.md
+  - command: uv run python -c "import shutil; shutil.move('{{project_name}}/README_api.md', '{{project_name}}/README.md')"
     when: "{{ project_type in ['api-monolith', 'api-microservice'] }}"
-  - command: mkdir -p {{project_name}}/migrations/versions # git won't commit empty directories
+  - command: uv run python -c "import os; os.makedirs('{{project_name}}/migrations/versions', exist_ok=True)"
     when: "{{ project_type in ['api-monolith', 'api-microservice'] }}"
-  - "cd {{project_name}} && uv sync "
+  - "cd {{project_name}} && uv sync"
+  


### PR DESCRIPTION
## Problem
Template tasks used Unix commands ('mv', 'mkdir') that don't work on Windows, causing template generation to fail on Windows systems.

## Changes
Replaced platform-specific shell commands with cross-platform Python equivalents using `uv run python` in _tasks section:
- `mv `-> `shutil.move()`
- `mkdir -p` -> `os.makedirs(..., exist_ok=True)` 