### PR TITLE
[fix] Switched from uv to uvx for python shell executions in copier tasks

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -94,10 +94,10 @@ _exclude:
   - "{{ '*/app/mcp' if project_type != 'mcp-server' else '' }}"
 
 _tasks:
-  - command: uv run --no-project python -c "import shutil; shutil.move('{{project_name}}/README_{{project_type}}.md', '{{project_name}}/README.md')"
+  - command: uvx python -c "import shutil; shutil.move('{{project_name}}/README_{{project_type}}.md', '{{project_name}}/README.md')"
     when: "{{ project_type in ['agent', 'mcp-server'] }}"
-  - command: uv run --no-project python -c "import shutil; shutil.move('{{project_name}}/README_api.md', '{{project_name}}/README.md')"
+  - command: uvx python -c "import shutil; shutil.move('{{project_name}}/README_api.md', '{{project_name}}/README.md')"
     when: "{{ project_type in ['api-monolith', 'api-microservice'] }}"
-  - command: uv run --no-project python -c "import os; os.makedirs('{{project_name}}/migrations/versions', exist_ok=True)"
+  - command: uvx python -c "import os; os.makedirs('{{project_name}}/migrations/versions', exist_ok=True)"
     when: "{{ project_type in ['api-monolith', 'api-microservice'] }}"
   - "cd {{project_name}} && uv sync"


### PR DESCRIPTION
Address the issue #66 - copier setup fails on step 2 for uv commands