### PR TITLE
fix: exclude chat files fro api-microservice template

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -95,6 +95,11 @@ _exclude:
   - "{{ 'app/services' if project_type != 'api-microservice' else '' }}"
   - "{{ 'app/repositories' if project_type != 'api-microservice' else '' }}"
   - "{{ 'app/api/routes/v1/user.py' if project_type != 'api-microservice' else '' }}"
+  - "{{ 'app/schemas/chat.py' if project_type == 'api-microservice' else '' }}"
+  - "{{ 'app/schemas/agent.py' if project_type == 'api-microservice' else '' }}"
+  - "{{ 'app/schemas/message.py' if project_type == 'api-microservice' else '' }}"
+  - "{{ 'app/schemas/deps.py' if project_type == 'api-microservice' else '' }}"
+  - "{{ 'app/api/routes/v1/chat.py' if project_type == 'api-microservice' else '' }}"
 
   - "{{ 'app/api' if project_type not in ['api-microservice', 'agent'] else '' }}"
   - "{{ 'app/models' if project_type not in ['api-microservice', 'agent'] else '' }}"


### PR DESCRIPTION
Closes #91 

### What was fixed
The `api-microservice` template was generating agent-related files by default, even though they are not applicable to this project type.

### Root cause
The file list in `copier.yaml` did not conditionally guard agent-related schemas and routes.

### Solution
Added Jinja conditionals in `copier.yaml` so the following files are only generated when `project_type == "api-microservice"`:

- `app/schemas/chat.py`
- `app/schemas/agent.py`
- `app/schemas/message.py`
- `app/schemas/deps.py`
- `app/api/routes/v1/chat.py`

### How to test
1. Generate a project using the `api-microservice` template
2. Verify that only the expected files are created
3. Generate other template types and confirm agent-related files are not present

### Environment
- OS: Ubuntu 24.04
- Python: 3.13