### PR TITLE
Update user schema exclusion logic in copier.yaml to account for SQLAdmin plugin

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -91,7 +91,7 @@ _exclude:
   - "{{ 'app/repositories.py' if project_type != 'api-monolith' else '' }}"
   - "{{ 'app/services.py' if project_type != 'api-monolith' else '' }}"
 
-  - "{{ 'app/schemas/user.py' if project_type != 'api-microservice' else '' }}"
+  - "{{ 'app/schemas/user.py' if project_type != 'api-microservice' and 'sqladmin' not in plugins else '' }}"
   - "{{ 'app/services' if project_type != 'api-microservice' else '' }}"
   - "{{ 'app/repositories' if project_type != 'api-microservice' else '' }}"
   - "{{ 'app/api/routes/v1/user.py' if project_type != 'api-microservice' else '' }}"


### PR DESCRIPTION
Closes https://github.com/the-momentum/python-ai-kit/issues/100

## Solution
Updated the exclusion rule in `copier.yaml` to check for the `sqladmin` plugin. Now `app/schemas/user.py` is included whenever `sqladmin` is enabled, regardless of project type.

