### PR TITLE
Add optional DVC with S3 remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,6 @@ uv tool install copier
 > [!TIP]
 > You can also just use `uvx` before `copier copy` command if you don't want to install this tool.
 
-Optionally, if you plan to enable DVC during setup, install it with:
-```bash
-uv tool install dvc
-```
-> [!IMPORTANT]
-> If you enabled DVC during setup: you need AWS CLI configured with a profile that has access to the DVC S3 bucket. After generating the project, set your profile locally (stays out of Git) in the project root:
-
-```bash
-dvc remote modify --local production profile <your-aws-profile>
-```
-
 To use this template, run:
 
 ```bash
@@ -44,6 +33,17 @@ copier update --trust --defaults
 > - your project HAS to be a git repo in order to use this command
 > - omit `--defaults` flag, if you want to update answers (like `python_versions`)
 > - you can also use flag `-r` here to update with template version from unreleased versions
+
+## 🔧 Optional add-ons
+
+Some setup options require extra tools to be installed beforehand. If you skip them, the template will fail when that option is selected.
+
+### DVC (Data Version Control)
+
+- **Requires:** `dvc` installed (e.g. `uv tool install dvc`) and, when enabled, **AWS CLI** with a profile that has access to your DVC S3 bucket.
+- **During setup:** You can enable DVC when prompted; you will then provide the full S3 path (starting with `s3://`) for the remote and the AWS region.
+- **After generation:** Set your AWS profile locally in the project root (stays out of Git):  
+  `dvc remote modify --local <remote-name> profile <your-aws-profile>` (use the remote name you chose during setup)
 
 ## Features
 
@@ -115,7 +115,6 @@ The generated project includes:
 - AI agent integration with Streamlit GUI
 - Comprehensive testing setup
 - Modern Python tooling (uv, ruff, etc.)
-- Optional [DVC](https://dvc.org/) with S3 remote – enable during setup if you need data/artifact versioning; requires AWS CLI and bucket access. When enabled, the generated project includes **README_DVC.md** with full usage instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ uv tool install copier
 > [!TIP]
 > You can also just use `uvx` before `copier copy` command if you don't want to install this tool.
 
+Optionally, if you plan to enable DVC during setup, install it with:
+```bash
+uv tool install dvc
+```
+> [!IMPORTANT]
+> If you enabled DVC during setup: you need AWS CLI configured with a profile that has access to the DVC S3 bucket. After generating the project, set your profile locally (stays out of Git) in the project root:
+
+```bash
+dvc remote modify --local production profile <your-aws-profile>
+```
+
 To use this template, run:
 
 ```bash
@@ -33,7 +44,6 @@ copier update --trust --defaults
 > - your project HAS to be a git repo in order to use this command
 > - omit `--defaults` flag, if you want to update answers (like `python_versions`)
 > - you can also use flag `-r` here to update with template version from unreleased versions
-
 
 ## Features
 
@@ -105,6 +115,7 @@ The generated project includes:
 - AI agent integration with Streamlit GUI
 - Comprehensive testing setup
 - Modern Python tooling (uv, ruff, etc.)
+- Optional [DVC](https://dvc.org/) with S3 remote – enable during setup if you need data/artifact versioning; requires AWS CLI and bucket access. When enabled, the generated project includes **README_DVC.md** with full usage instructions.
 
 ---
 

--- a/copier.yaml
+++ b/copier.yaml
@@ -77,23 +77,19 @@ default_python_version:
     {% endfor %}
 
 add_dvc:
-  type: str
+  type: bool
   help: Add DVC (Data Version Control) to the project?
-  default: "no"
-  choices:
-    - "no"
-    - "yes"
+  default: false
 
 dvc_bucket_name:
   type: str
-  help: S3 bucket name for DVC remote (e.g. dvc-production-store)
-  when: "{{ add_dvc == 'yes' }}"
+  help: S3 bucket name for DVC remote
+  when: "{{ add_dvc }}"
 
 dvc_region:
   type: str
   help: AWS region for DVC remote
-  default: "{{ 'eu-central-1' if dvc_bucket_name == 'dvc-production-store' else '' }}"
-  when: "{{ add_dvc == 'yes' }}"
+  when: "{{ add_dvc }}"
 
 _exclude:
   - "{{ 'migrations' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
@@ -132,7 +128,7 @@ _exclude:
   - "{{ 'app/integrations/sqladmin' if 'sqladmin' not in plugins else '' }}"
   - "{{ 'app/integrations/celery' if 'celery' not in plugins else '' }}"
   - "{{ 'app/integrations/sentry.py' if 'sentry' not in plugins else '' }}"
-  - "{{ 'README_DVC.md' if add_dvc != 'yes' else '' }}"
+  - "{{ 'README_DVC.md' if not add_dvc else '' }}"
 
 _tasks:
   - command: uvx python -c "import shutil; shutil.move('README_{{project_type}}.md', 'README.md')"
@@ -144,11 +140,11 @@ _tasks:
   - "uv sync --group code-quality"
   - "git init && git checkout -b master"
   - command: dvc init
-    when: "{{ add_dvc == 'yes' }}"
+    when: "{{ add_dvc }}"
   - command: dvc remote add -d production s3://{{ dvc_bucket_name }}/{{ project_name }}
-    when: "{{ add_dvc == 'yes' }}"
+    when: "{{ add_dvc }}"
   - command: dvc remote modify production region {{ dvc_region }}
-    when: "{{ add_dvc == 'yes' }}"
+    when: "{{ add_dvc }}"
   - "git add --all"
   - command: uvx python -c "import subprocess; result = subprocess.run(['uv', 'run', 'pre-commit', 'run', '--all-files']); exit(0)"
   - "git add --all"

--- a/copier.yaml
+++ b/copier.yaml
@@ -76,6 +76,25 @@ default_python_version:
     - "{{ver}}"
     {% endfor %}
 
+add_dvc:
+  type: str
+  help: Add DVC (Data Version Control) to the project?
+  default: "no"
+  choices:
+    - "no"
+    - "yes"
+
+dvc_bucket_name:
+  type: str
+  help: S3 bucket name for DVC remote (e.g. dvc-production-store)
+  when: "{{ add_dvc == 'yes' }}"
+
+dvc_region:
+  type: str
+  help: AWS region for DVC remote
+  default: "{{ 'eu-central-1' if dvc_bucket_name == 'dvc-production-store' else '' }}"
+  when: "{{ add_dvc == 'yes' }}"
+
 _exclude:
   - "{{ 'migrations' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
   - "{{ 'app/database.py' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
@@ -113,7 +132,8 @@ _exclude:
   - "{{ 'app/integrations/sqladmin' if 'sqladmin' not in plugins else '' }}"
   - "{{ 'app/integrations/celery' if 'celery' not in plugins else '' }}"
   - "{{ 'app/integrations/sentry.py' if 'sentry' not in plugins else '' }}"
-  
+  - "{{ 'README_DVC.md' if add_dvc != 'yes' else '' }}"
+
 _tasks:
   - command: uvx python -c "import shutil; shutil.move('README_{{project_type}}.md', 'README.md')"
     when: "{{ project_type in ['agent', 'mcp-server'] }}"
@@ -122,8 +142,14 @@ _tasks:
   - command: uvx python -c "import os; os.makedirs('migrations/versions', exist_ok=True)"
     when: "{{ project_type in ['api-monolith', 'api-microservice', 'agent'] }}"
   - "uv sync --group code-quality"
-  - "git init && git checkout -b master && git add --all"
+  - "git init && git checkout -b master"
+  - command: dvc init
+    when: "{{ add_dvc == 'yes' }}"
+  - command: dvc remote add -d production s3://{{ dvc_bucket_name }}/{{ project_name }}
+    when: "{{ add_dvc == 'yes' }}"
+  - command: dvc remote modify production region {{ dvc_region }}
+    when: "{{ add_dvc == 'yes' }}"
+  - "git add --all"
   - command: uvx python -c "import subprocess; result = subprocess.run(['uv', 'run', 'pre-commit', 'run', '--all-files']); exit(0)"
   - "git add --all"
   - command: uvx python -c "import subprocess; subprocess.run(['git', 'commit', '-m', 'Initial commit'])"
-

--- a/copier.yaml
+++ b/copier.yaml
@@ -81,9 +81,15 @@ add_dvc:
   help: Add DVC (Data Version Control) to the project?
   default: false
 
-dvc_bucket_name:
+dvc_remote_name:
   type: str
-  help: S3 bucket name for DVC remote
+  help: Name for the DVC remote
+  default: "storage"
+  when: "{{ add_dvc }}"
+
+dvc_remote_url:
+  type: str
+  help: Full S3 path for DVC remote (e.g. s3://bucket-name/path)
   when: "{{ add_dvc }}"
 
 dvc_region:
@@ -128,9 +134,20 @@ _exclude:
   - "{{ 'app/integrations/sqladmin' if 'sqladmin' not in plugins else '' }}"
   - "{{ 'app/integrations/celery' if 'celery' not in plugins else '' }}"
   - "{{ 'app/integrations/sentry.py' if 'sentry' not in plugins else '' }}"
-  - "{{ 'README_DVC.md' if not add_dvc else '' }}"
+  - "{{ 'README_DVC.md.jinja' if not add_dvc else '' }}"
 
 _tasks:
+  - command: |
+      uvx python -c "
+      import subprocess, sys
+      msg = 'DVC is not installed or not in PATH. Install it with: uv tool install dvc'
+      try:
+          subprocess.run(['dvc', '--version'], capture_output=True, timeout=10, check=True)
+      except (subprocess.CalledProcessError, FileNotFoundError):
+          sys.stderr.write(msg + chr(10))
+          sys.exit(1)
+      "
+    when: "{{ add_dvc }}"
   - command: uvx python -c "import shutil; shutil.move('README_{{project_type}}.md', 'README.md')"
     when: "{{ project_type in ['agent', 'mcp-server'] }}"
   - command: uvx python -c "import shutil; shutil.move('README_api.md', 'README.md')"
@@ -141,9 +158,9 @@ _tasks:
   - "git init && git checkout -b master"
   - command: dvc init
     when: "{{ add_dvc }}"
-  - command: dvc remote add -d production s3://{{ dvc_bucket_name }}/{{ project_name }}
+  - command: dvc remote add -d {{ dvc_remote_name }} {{ dvc_remote_url }}
     when: "{{ add_dvc }}"
-  - command: dvc remote modify production region {{ dvc_region }}
+  - command: dvc remote modify {{ dvc_remote_name }} region {{ dvc_region }}
     when: "{{ add_dvc }}"
   - "git add --all"
   - command: uvx python -c "import subprocess; result = subprocess.run(['uv', 'run', 'pre-commit', 'run', '--all-files']); exit(0)"

--- a/python-ai-kit/README_DVC.md
+++ b/python-ai-kit/README_DVC.md
@@ -1,0 +1,66 @@
+# Data Version Control (DVC)
+
+DVC tracks large files (datasets, model weights, audio samples, etc.) outside of Git. It stores pointer files (`.dvc`) in your Git repository while the actual data lives in a shared S3 bucket. This means every commit in Git maps to a specific version of the data, without bloating the repository.
+
+## When to use DVC
+
+Use DVC whenever your project has files that are too large or too numerous for Git. Common examples:
+
+- Training datasets
+- Model weights and checkpoints
+- Audio/video/image corpora
+- Preprocessed feature files
+
+## Prerequisites
+
+- AWS CLI configured with a profile that has access to the DVC S3 bucket
+
+To get S3 access, ask your DevOps team to add your IAM user to the group.
+
+## Setup
+
+Configure your AWS profile. Use `--local` so it stays out of Git (each developer may use a different profile name):
+
+```bash
+dvc remote modify --local production profile <your-aws-profile>
+```
+
+## Daily workflow
+
+### Tracking a new file or directory
+
+```bash
+dvc add data/dataset.csv
+```
+
+This creates `data/dataset.csv.dvc` (a small pointer file) and adds `data/dataset.csv` to `.gitignore`. Commit both:
+
+```bash
+git add data/dataset.csv.dvc data/.gitignore
+git commit -m "track dataset"
+```
+
+### Pushing data to remote
+
+```bash
+dvc push
+```
+
+### Pulling data after cloning or switching branches
+
+```bash
+dvc pull
+```
+
+### Checking what's changed
+
+```bash
+dvc status
+```
+
+## How it works
+
+When you run `dvc add`, DVC hashes the file contents and stores the hash in the `.dvc` pointer file. The actual data is cached locally (in `.dvc/cache/`) and uploaded to S3 on `dvc push`. When a teammate runs `dvc pull`, DVC reads the `.dvc` files, downloads the matching data from S3, and places it in the working directory.
+
+The `.dvc/cache/` directory and actual data files are gitignored. Only the small `.dvc` pointer files are committed to Git.
+

--- a/python-ai-kit/README_DVC.md.jinja
+++ b/python-ai-kit/README_DVC.md.jinja
@@ -22,7 +22,7 @@ To get S3 access, ask your DevOps team to add your IAM user to the group.
 Configure your AWS profile. Use `--local` so it stays out of Git (each developer may use a different profile name):
 
 ```bash
-dvc remote modify --local production profile <your-aws-profile>
+dvc remote modify --local {{ dvc_remote_name }} profile <your-aws-profile>
 ```
 
 ## Daily workflow
@@ -63,4 +63,3 @@ dvc status
 When you run `dvc add`, DVC hashes the file contents and stores the hash in the `.dvc` pointer file. The actual data is cached locally (in `.dvc/cache/`) and uploaded to S3 on `dvc push`. When a teammate runs `dvc pull`, DVC reads the `.dvc` files, downloads the matching data from S3, and places it in the working directory.
 
 The `.dvc/cache/` directory and actual data files are gitignored. Only the small `.dvc` pointer files are committed to Git.
-


### PR DESCRIPTION
- Optional DVC in Copier - new prompt (yes/no) to enable DVC when generating a project; if yes, ask for S3 bucket name and AWS region (default region only when bucket is dvc-production-store).
- Single initial commit - when DVC is enabled, dvc init and remote config run after git init. All files, including .dvc, go into one “Initial commit” (no separate DVC commit).
- README_DVC.md in generated project - new file (only when DVC is enabled).