### PR TITLE
fix: add build directive to services reusing app image

### DIFF
--- a/python-ai-kit/docker-compose.yml.jinja
+++ b/python-ai-kit/docker-compose.yml.jinja
@@ -43,6 +43,9 @@ services:
 
   celery-worker:
     container_name: celery-worker__{{project_name}}
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: {{project_name}}:latest
     command: scripts/start/worker.sh
     volumes:
@@ -56,6 +59,9 @@ services:
 
   celery-beat:
     container_name: celery-beat__{{project_name}}
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: {{project_name}}:latest
     command: scripts/start/beat.sh
     volumes:
@@ -69,6 +75,9 @@ services:
 
   flower:
     container_name: flower__{{project_name}}
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: {{project_name}}:latest
     command: scripts/start/flower.sh
     volumes:

--- a/python-ai-kit/docker-compose.yml.jinja
+++ b/python-ai-kit/docker-compose.yml.jinja
@@ -1,3 +1,7 @@
+x-shared-build: &shared-build
+  context: .
+  dockerfile: Dockerfile
+
 services:
   db:
     image: postgres:18
@@ -17,9 +21,7 @@ services:
       - postgres_data:/var/lib/postgresql
 
   app:
-    build:
-        context: .
-        dockerfile: Dockerfile
+    build: *shared-build
     container_name: backend__{{project_name}}
     image: {{project_name}}:latest
     command: scripts/start/app.sh
@@ -43,9 +45,7 @@ services:
 
   celery-worker:
     container_name: celery-worker__{{project_name}}
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: *shared-build
     image: {{project_name}}:latest
     command: scripts/start/worker.sh
     volumes:
@@ -59,9 +59,7 @@ services:
 
   celery-beat:
     container_name: celery-beat__{{project_name}}
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: *shared-build
     image: {{project_name}}:latest
     command: scripts/start/beat.sh
     volumes:
@@ -75,9 +73,7 @@ services:
 
   flower:
     container_name: flower__{{project_name}}
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: *shared-build
     image: {{project_name}}:latest
     command: scripts/start/flower.sh
     volumes:


### PR DESCRIPTION
Services `celery-worker`, `celery-beat`, and `flower` reference image `{project}:latest` without a build directive, causing Docker Compose to attempt a pull from Docker Hub on every run

<img width="666" height="542" alt="image" src="https://github.com/user-attachments/assets/725e62db-f449-4a2b-b3d2-966c4aa54406" />
