### PR TITLE
fix: Fix app/__init__.py template

### DIFF
--- a/python-ai-kit/app/__init__.py.jinja
+++ b/python-ai-kit/app/__init__.py.jinja
@@ -5,7 +5,7 @@ try:
     {% if project_type == "api-monolith" %}
     from app.user.models import User  # noqa: F401
     {% elif project_type == "api-microservice" %}
-    from app.models import *  # noqa: F401
+    from app.models import *  # noqa: F401, F403
     {% endif %}
 except ImportError:
     traceback.print_exc()


### PR DESCRIPTION
[Related issue](https://github.com/the-momentum/python-ai-kit/issues/92)

### What was done

Modified the `# noqa` comment on the wildcard import line in `app/__init__.py` to include both **F401** and **F403** codes.

### Why it was done

The previous configuration only suppressed **F401**, causing the `ruff check` to fail on the **F403** violation. Adding both codes ensures the template passes pre-commit checks out of the box while maintaining the convenience of exported models in the package root.

---

### Test Instructions
To verify the fix and ensure the generated project passes linting:
1. **Generate the project:**
```bash
copier copy $TEMPLATE_LOCAL_PATH $PROJECT_LOCAL_PATH --trust
```
To reproduce reported issue choose `api-microservice` project type.

2. **Run the linter:**
```bash
uv run ruff check
```
