### PR TITLE
fix: Add missing return type annotations

### DIFF
--- a/python-ai-kit/app/api/routes/v1/chat.py
+++ b/python-ai-kit/app/api/routes/v1/chat.py
@@ -24,7 +24,7 @@ class ChatResponse(BaseModel):
     error: str | None = None
 
 
-@router.post("/chat")
+@router.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest) -> ChatResponse:
     """Chat endpoint using workflow with AgentManager factory."""
     logger.info(f"Received chat request: {request.message[:50]}... (MCP: {request.use_mcp})")

--- a/python-ai-kit/app/api/routes/v1/chat.py
+++ b/python-ai-kit/app/api/routes/v1/chat.py
@@ -24,7 +24,7 @@ class ChatResponse(BaseModel):
     error: str | None = None
 
 
-@router.post("/chat", response_model=ChatResponse)
+@router.post("/chat")
 async def chat(request: ChatRequest) -> ChatResponse:
     """Chat endpoint using workflow with AgentManager factory."""
     logger.info(f"Received chat request: {request.message[:50]}... (MCP: {request.use_mcp})")

--- a/python-ai-kit/app/api/routes/v1/chat.py
+++ b/python-ai-kit/app/api/routes/v1/chat.py
@@ -25,7 +25,7 @@ class ChatResponse(BaseModel):
 
 
 @router.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest) -> ChatResponse:
+async def chat(request: ChatRequest):
     """Chat endpoint using workflow with AgentManager factory."""
     logger.info(f"Received chat request: {request.message[:50]}... (MCP: {request.use_mcp})")
     

--- a/python-ai-kit/app/api/routes/v1/chat.py
+++ b/python-ai-kit/app/api/routes/v1/chat.py
@@ -25,7 +25,7 @@ class ChatResponse(BaseModel):
 
 
 @router.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest):
+async def chat(request: ChatRequest) -> ChatResponse:
     """Chat endpoint using workflow with AgentManager factory."""
     logger.info(f"Received chat request: {request.message[:50]}... (MCP: {request.use_mcp})")
     

--- a/python-ai-kit/app/schemas/deps.py
+++ b/python-ai-kit/app/schemas/deps.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from app.agent.engines.routers import GenericRouter
 from app.agent.engines.guardrails import OutputReformatterWorker
 from app.agent.agent_manager import agent_manager
 from app.config import settings
 
 
-async def get_workflow_dependencies(mcp_url: str | None = None):
+async def get_workflow_dependencies(mcp_url: str | None = None) -> dict[str, Any]:
     """Get dependencies needed for the workflow"""
     use_mcp = mcp_url is not None
     await agent_manager.initialize(use_mcp=use_mcp, mcp_url=mcp_url)

--- a/python-ai-kit/pyproject.toml.jinja
+++ b/python-ai-kit/pyproject.toml.jinja
@@ -78,7 +78,7 @@ ignore = [
     "RET503", # implicit-return
 ]
 
-{% if project_type == "api-monolith" %}
+{% if project_type in ["api-monolith", "api-microservice", "agent"] %}
 [tool.ruff.lint.per-file-ignores]
 "app/*/routes/*/*.py" = ["ANN201"]
 # ignoring annotation of return type of FastAPI endpoints to use just reponse_model


### PR DESCRIPTION
### What was done
Add missing return type annotations pointed by `ruff check`

### Why it was done
While resolving [issue](https://github.com/the-momentum/python-ai-kit/issues/92) I've found out that there are two more checks that does not pass the check out of the box. 

---

### Test Instructions
To verify the fix and ensure the generated project passes linting:
1. **Generate the project:**
```bash
copier copy $TEMPLATE_LOCAL_PATH $PROJECT_LOCAL_PATH --trust
```
To reproduce reported issue choose `api-microservice` project type.

2. **Run the linter:**
```bash
uv run ruff check
```
