### PR TITLE
migrate agent template to pydantic-ai v2

### DIFF
--- a/python-ai-kit/app/agent/engines/agent_base.py
+++ b/python-ai-kit/app/agent/engines/agent_base.py
@@ -4,7 +4,7 @@ from typing import Any, Type
 from pydantic_ai import Agent, RunContext, UsageLimits
 from pydantic_ai.messages import ModelMessage
 from pydantic_ai.run import AgentRunResult
-from pydantic_ai.mcp import MCPServerStreamableHTTP
+from pydantic_ai.mcp import MCPToolset
 
 from app.config import settings
 from app.utils.llm_vendor import set_api_key_for_vendor
@@ -56,8 +56,8 @@ class BaseAgent(ABC):
                             print(f"Invalid MCP URL format: {mcp_url}")
                         continue
                     
-                    mcp_server = MCPServerStreamableHTTP(mcp_url)
-                    toolsets.append(mcp_server)
+                    mcp_toolset = MCPToolset(mcp_url)
+                    toolsets.append(mcp_toolset)
                     if self.verbose:
                         print(f"MCP server enabled: {mcp_url}")
                 except Exception as e:
@@ -104,6 +104,6 @@ class BaseAgent(ABC):
         result = await self.agent.run(**run_kwargs)
         
         if self.verbose:
-            print(f"Usage: {result.usage()}")
+            print(f"Usage: {result.usage}")
         
         return result

--- a/python-ai-kit/pyproject.toml.jinja
+++ b/python-ai-kit/pyproject.toml.jinja
@@ -17,7 +17,7 @@ dependencies = [
     "fastmcp>=2.12",
     "pydantic>=2.11.7",
     {% elif project_type == "agent" %}
-    "pydantic-ai>=1.0.8",
+    "pydantic-ai>=2.5.1,<3",
     "streamlit>=1.50.0",
     {% endif %}
     {% if project_type in ["api-monolith", "api-microservice", "agent"] %}


### PR DESCRIPTION
## Changes
- Replace `MCPServerStreamableHTTP` with `MCPToolset` in `agent_base.py` - a drop-in replacement that accepts a streamable-HTTP URL directly and is passed to `Agent(toolsets=[...])` the same way.
- Change `result.usage()` to `result.usage` - it became a property in v2.
- Bump the dependency to `pydantic-ai>=2.5.1,<3`. The upper bound prevents the same class of breakage on the next major release.


## Testing
- Generated a fresh `agent` project from this branch (`copier copy --vcs-ref=HEAD`); `uv sync` resolves pydantic-ai 2.5.1 and `app.agent.engines.agent_base` imports cleanly.
- Smoke-tested the full pydantic-ai API surface used by the template on 2.5.1
  (`Agent` construction with `tools`/`deps_type`/`instructions`/`output_type`,
  `@agent.instructions`, `run()` with `message_history`/`deps`/`usage_limits`,
  `result.output`, `pydantic_graph` imports) - no other breaking changes affect the template
  
Closes #63