### PR TITLE
Mount entire root_project as volume in app service to persist generat…

### DIFF
--- a/python-ai-kit/docker-compose.yml.jinja
+++ b/python-ai-kit/docker-compose.yml.jinja
@@ -35,12 +35,8 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./app:/root_project/app
-      - type: bind
-        source: ./config/.env
-        target: /root_project/config/.env
-        bind:
-          create_host_path: false
+      - .:/root_project
+      - /root_project/.venv
     restart: on-failure
 
   celery-worker:


### PR DESCRIPTION
## Changes
- Mount the whole project (`.:/root_project`) in the `app` service with an
  anonymous volume for `/root_project/.venv`, consistent with the
  `celery-worker`, `celery-beat` and `flower` services. The previous
  `./app` and `config/.env` mounts are covered by the project mount.
- Add `migrations/versions/.gitkeep` so the folder is tracked in the
  generated project's repo - without it, cloning the project before the
  first migration exists would leave `versions/` missing on the host and
  `alembic revision` would fail in the container (the bind mount shadows
  the image contents).

Closes #90