### PR TITLE
Exclude unused files from mcp-server template

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -138,10 +138,21 @@ _exclude:
   - "{{ 'README_mcp-server.md' if project_type != 'mcp-server' else '' }}"
   - "{{ 'app/mcp' if project_type != 'mcp-server' else '' }}"
 
+  - "{{ 'app/utils/api_utils.py' if project_type != 'api-monolith' else '' }}"
+  - "{{ 'app/utils/hateoas.py' if project_type != 'api-monolith' else '' }}"
+  - "{{ 'app/utils/conversion.py' if project_type != 'api-monolith' else '' }}"
+  - "{{ 'app/utils/healthcheck.py' if project_type != 'api-monolith' else '' }}"
+  - "{{ 'app/utils/exceptions.py' if project_type not in ['api-monolith', 'api-microservice'] else '' }}"
+  - "{{ 'app/middlewares.py' if project_type == 'mcp-server' else '' }}"
+  - "{{ 'scripts/healthchecks' if project_type not in ['api-monolith', 'api-microservice'] else '' }}"
+  - "{{ 'scripts/start' if project_type == 'mcp-server' else '' }}"
+  - "{{ 'prestart.sh' if project_type == 'mcp-server' else '' }}"
+  - "{{ 'alembic.ini' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
+
   - "{{ 'app/integrations/sqladmin' if 'sqladmin' not in plugins else '' }}"
   - "{{ 'app/integrations/celery' if 'celery' not in plugins else '' }}"
   - "{{ 'app/integrations/sentry.py' if 'sentry' not in plugins else '' }}"
-  - "{{ 'README_DVC.md.jinja' if not add_dvc else '' }}"
+  - "{{ 'README_DVC.md' if not add_dvc else '' }}"
 
 _tasks:
   - command: |

--- a/python-ai-kit/app/main.py.jinja
+++ b/python-ai-kit/app/main.py.jinja
@@ -31,7 +31,9 @@ from app.integrations.sentry import init_sentry
 from app.integrations.sqladmin import add_admin_views
 from app.integrations.sqladmin import admin_authentication_backend 
 {% endif %}
+{% if project_type != "mcp-server" %}
 from app.middlewares import add_cors_middleware
+{% endif %}
 {% if project_type in ["api-monolith", "api-microservice"] %}
 from app.utils.exceptions import handle_exception
 {% endif %}


### PR DESCRIPTION
The mcp-server template no longer generates files it can't use: DB/API leftovers
(`app/schemas.py`, `app/middlewares.py`, unused `app/utils/*` modules,
`scripts/healthchecks`, `scripts/start`, `prestart.sh`, `alembic.ini`). Several of
them imported `fastapi`/`psycopg`, which aren't mcp-server dependencies, so the
generated server crashed on startup (`ModuleNotFoundError`). The unconditional
`app.middlewares` import in `main.py.jinja` is now conditional.

Also fixes `README_DVC.md` being generated despite `add_dvc=false` - `_exclude`
patterns match rendered paths, so the `.jinja` suffix never matched.

Verified by generating all project types: mcp-server now passes `ty check` and
responds to MCP `initialize` over HTTP; api-monolith and api-microservice keep
all their files (microservice even drops 5 pre-existing `ty` errors from the
unused `healthcheck.py`).

**Note: the `app/schemas.py` exclusion becomes obsolete once #89
(`fix/schemas-filter-params-location`) is merged - whichever lands second should
drop that single line.**

Edit: line dropped

Closes #56