### PR TITLE
Fix project name and typos in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,12 +1,11 @@
-# How to contribute to the FHIR MCP Server
+# How to contribute to the Python AI Kit
 
 1. Fork the repository.
 2. Clone your fork.
 3. Make sure `uv` and [`just`](https://github.com/casey/just) are installed.
-5. Generate project of chosen template type.
-6. Switch there, develop changes.
-7. Come back to forked main repository, create new branch nad move your changes to corresponding directories here, remember to include jinja syntax if some changes are not binded to all templates types.
-10. Commit your chages and push entire branch to the remote (`git push -u origin <local_branch_name>`). It will automatically create a Pull Request here.
+4. Generate a project of the chosen template type.
+5. Switch there, develop changes.
+6. Come back to the forked main repository, create a new branch and move your changes to the corresponding directories here. Remember to include Jinja syntax if some changes are not bound to all template types.
+7. Commit your changes and push the entire branch to the remote (`git push -u origin <local_branch_name>`). It will automatically create a Pull Request here.
 
 Your contributions are more than welcome! :)
-


### PR DESCRIPTION
Replaces the leftover "FHIR MCP Server" title with "Python AI Kit", fixes step numbering (1-7) and typos (nad/chages/binded).

Closes #99 
