### PR TITLE
Feat/observability and tracing

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -157,6 +157,7 @@ _exclude:
   - "{{ 'app/integrations/sqladmin' if 'sqladmin' not in plugins else '' }}"
   - "{{ 'app/integrations/celery' if 'celery' not in plugins else '' }}"
   - "{{ 'app/integrations/sentry.py' if 'sentry' not in plugins else '' }}"
+  - "{{ 'app/integrations/mlflow.py' if 'mlflow' not in plugins else '' }}"
   - "{{ 'README_DVC.md' if not add_dvc else '' }}"
 
 _tasks:

--- a/copier.yaml
+++ b/copier.yaml
@@ -22,6 +22,9 @@ plugins:
     - "sqladmin"
     - "celery"
     - "sentry"
+    {% if project_type == "agent" %}
+    - "mlflow"
+    {% endif %}
     {% else %}
     []
     {% endif %}
@@ -30,6 +33,9 @@ plugins:
     SQLAdmin [interface for database management]: sqladmin
     Celery [task queue]: celery
     Sentry [error tracking]: sentry
+    {% if project_type == "agent" %}
+    MLflow [observability and tracing]: mlflow
+    {% endif %}
     {% else %}
     {}
     {% endif %}

--- a/copier.yaml
+++ b/copier.yaml
@@ -110,8 +110,8 @@ _exclude:
   - "{{ 'app/utils/mappings_meta.py' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
 
   - "{{ 'README_api.md' if project_type not in ['api-monolith', 'api-microservice'] else '' }}"
-  - "{{ 'Dockerfile' if project_type not in ['api-monolith', 'api-microservice'] else '' }}"
-  - "{{ 'docker-compose.yml' if project_type not in ['api-monolith', 'api-microservice'] else '' }}"
+  - "{{ 'Dockerfile' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
+  - "{{ 'docker-compose.yml' if project_type not in ['api-monolith', 'api-microservice', 'agent'] else '' }}"
 
   - "{{ 'app/api.py' if project_type != 'api-monolith' else '' }}"
   - "{{ 'app/user' if project_type != 'api-monolith' else '' }}"
@@ -158,6 +158,7 @@ _exclude:
   - "{{ 'app/integrations/celery' if 'celery' not in plugins else '' }}"
   - "{{ 'app/integrations/sentry.py' if 'sentry' not in plugins else '' }}"
   - "{{ 'app/integrations/mlflow.py' if 'mlflow' not in plugins else '' }}"
+  - "{{ 'docker' if 'mlflow' not in plugins else '' }}"
   - "{{ 'README_DVC.md' if not add_dvc else '' }}"
 
 _tasks:

--- a/python-ai-kit/AGENTS.md.jinja
+++ b/python-ai-kit/AGENTS.md.jinja
@@ -523,7 +523,7 @@ Verify a new tool by listing tools and invoking it through an MCP client (e.g. t
 
 | Command | Description |
 |---------|-------------|
-{% if project_type in ["api-monolith", "api-microservice"] %}
+{% if project_type in ["api-monolith", "api-microservice", "agent"] %}
 | `just build` | Build Docker images |
 | `just run` / `just up` | Start detached / foreground |
 | `just stop` / `just down` | Stop / remove containers |
@@ -551,6 +551,9 @@ Verify a new tool by listing tools and invoking it through an MCP client (e.g. t
 - Streamlit GUI: `uv run streamlit run app/gui.py`
 {% if "celery" in plugins %}
 - Flower (Celery monitoring): start it via `scripts/start/flower.sh`, then http://localhost:5555
+{% endif %}
+{% if "mlflow" in plugins %}
+- MLflow UI (tracing): http://localhost:5000 (the `mlflow` compose service)
 {% endif %}
 {% endif %}
 

--- a/python-ai-kit/AGENTS.md.jinja
+++ b/python-ai-kit/AGENTS.md.jinja
@@ -558,7 +558,7 @@ Verify a new tool by listing tools and invoking it through an MCP client (e.g. t
 {% if project_type in ["api-monolith", "api-microservice"] %}
 Python {{ default_python_version }} · FastAPI · SQLAlchemy 2.0 · PostgreSQL · Alembic · Pydantic 2{% if "celery" in plugins %} · Celery + Redis{% endif %}{% if "sqladmin" in plugins %} · SQLAdmin{% endif %}{% if "sentry" in plugins %} · Sentry{% endif %} · Ruff · `ty` · `uv`
 {% elif project_type == "agent" %}
-Python {{ default_python_version }} · Pydantic AI · pydantic-graph · FastAPI · Streamlit · SQLAlchemy 2.0 · PostgreSQL · Alembic{% if "celery" in plugins %} · Celery + Redis{% endif %}{% if "sqladmin" in plugins %} · SQLAdmin{% endif %}{% if "sentry" in plugins %} · Sentry{% endif %} · Ruff · `ty` · `uv`
+Python {{ default_python_version }} · Pydantic AI · pydantic-graph · FastAPI · Streamlit · SQLAlchemy 2.0 · PostgreSQL · Alembic{% if "celery" in plugins %} · Celery + Redis{% endif %}{% if "sqladmin" in plugins %} · SQLAdmin{% endif %}{% if "sentry" in plugins %} · Sentry{% endif %}{% if "mlflow" in plugins %} · MLflow{% endif %} · Ruff · `ty` · `uv`
 {% elif project_type == "mcp-server" %}
 Python {{ default_python_version }} · FastMCP · Pydantic 2 · Ruff · `ty` · `uv`
 {% endif %}

--- a/python-ai-kit/README_agent.md.jinja
+++ b/python-ai-kit/README_agent.md.jinja
@@ -19,6 +19,36 @@ echo "API_KEY=your_api_key_here" > config/.env
 
 Replace `your_api_key_here` with your actual API key for the LLM provider you're using.
 
+## 🐳 Running with Docker
+
+The project ships with a `docker-compose.yml` that starts PostgreSQL and the FastAPI app{% if "celery" in plugins %}, plus Redis and the Celery worker/beat/Flower services{% endif %}{% if "mlflow" in plugins %}, plus an MLflow tracking server{% endif %}. Make sure `config/.env` exists first, then:
+
+```bash
+just up       # foreground (just run for detached)
+just migrate  # apply database migrations (run from the host)
+```
+
+The API is available at http://localhost:8000 (Swagger: `/docs`).
+{% if "mlflow" in plugins %}
+
+## 📊 Tracing with MLflow
+
+Agent runs (LLM calls, tool calls, MCP tool calls) can be traced to MLflow. Enable it in `config/.env`:
+
+```bash
+MLFLOW_TRACING_ENABLED=True
+```
+
+Browse traces in the MLflow UI at http://localhost:5000 (experiment set by `MLFLOW_EXPERIMENT`, default `agent`).
+
+The default `MLFLOW_TRACKING_URI=http://mlflow:5000` targets the `mlflow` docker compose service. When running the app outside docker (e.g. `uv run fastapi dev app/main.py` or the Streamlit GUI), start a local server and point the URI at it:
+
+```bash
+uv run mlflow server --backend-store-uri sqlite:///mlflow.db --port 5000
+# and in config/.env: MLFLOW_TRACKING_URI="http://localhost:5000"
+```
+{% endif %}
+
 ## 🏗️ Architecture Overview
 
 This framework provides building blocks for creating custom AI agent workflows:

--- a/python-ai-kit/app/api/routes/v1/chat.py.jinja
+++ b/python-ai-kit/app/api/routes/v1/chat.py.jinja
@@ -9,6 +9,9 @@ from app.agent.workflows.agent_workflow import user_assistant_graph
 from app.agent.workflows.generation_events import WorkflowState
 from app.agent.workflows.nodes import StartNode
 from app.config import settings
+{% if "mlflow" in plugins %}
+from app.integrations.mlflow import trace_chat
+{% endif %}
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -39,6 +42,18 @@ async def chat(request: ChatRequest):
 
         initial_state = WorkflowState()
 
+        {% if "mlflow" in plugins %}
+        with trace_chat(request.message) as span:
+            result = await asyncio.wait_for(
+                user_assistant_graph.run(
+                    inputs=StartNode(),
+                    state=initial_state,
+                    deps=manager.to_deps(message=request.message, language=settings.default_language),
+                ),
+                timeout=settings.timeout,
+            )
+            span.set_outputs(result)
+        {% else %}
         result = await asyncio.wait_for(
             user_assistant_graph.run(
                 inputs=StartNode(),
@@ -47,6 +62,7 @@ async def chat(request: ChatRequest):
             ),
             timeout=settings.timeout,
         )
+        {% endif %}
 
         logger.info("Chat request processed successfully")
         return ChatResponse(response=result)

--- a/python-ai-kit/app/config.py.jinja
+++ b/python-ai-kit/app/config.py.jinja
@@ -128,6 +128,15 @@ class Settings(BaseSettings):
     # 2. .env
     # 3. default values in pydantic settings
 
+    {% if "mlflow" in plugins %}
+
+    # MLflow SETTINGS
+    MLFLOW_TRACING_ENABLED: bool = False
+    MLFLOW_TRACKING_URI: str = "http://localhost:5000"
+    MLFLOW_EXPERIMENT: str = "agent"
+
+    {% endif %}
+
 
 @lru_cache()
 def _get_settings() -> Settings:

--- a/python-ai-kit/app/config.py.jinja
+++ b/python-ai-kit/app/config.py.jinja
@@ -132,7 +132,7 @@ class Settings(BaseSettings):
 
     # MLflow SETTINGS
     MLFLOW_TRACING_ENABLED: bool = False
-    MLFLOW_TRACKING_URI: str = "http://localhost:5000"
+    MLFLOW_TRACKING_URI: str = "http://mlflow:5000"
     MLFLOW_EXPERIMENT: str = "agent"
 
     {% endif %}

--- a/python-ai-kit/app/gui.py.jinja
+++ b/python-ai-kit/app/gui.py.jinja
@@ -35,6 +35,12 @@ from app.agent.factories.workflow_factory import WorkflowAgentFactory
 from app.agent.workflows.agent_workflow import user_assistant_graph
 from app.agent.workflows.generation_events import WorkflowState
 from app.agent.workflows.nodes import StartNode
+{% if "mlflow" in plugins %}
+from app.integrations.mlflow import init_tracing
+
+# cache_resource so tracing is initialised once per process, not on every Streamlit rerun
+st.cache_resource(init_tracing)()
+{% endif %}
 
 if "chats" not in st.session_state:
     st.session_state.chats = 1

--- a/python-ai-kit/app/gui.py.jinja
+++ b/python-ai-kit/app/gui.py.jinja
@@ -36,7 +36,7 @@ from app.agent.workflows.agent_workflow import user_assistant_graph
 from app.agent.workflows.generation_events import WorkflowState
 from app.agent.workflows.nodes import StartNode
 {% if "mlflow" in plugins %}
-from app.integrations.mlflow import init_tracing
+from app.integrations.mlflow import init_tracing, trace_chat
 
 # cache_resource so tracing is initialised once per process, not on every Streamlit rerun
 st.cache_resource(init_tracing)()
@@ -249,6 +249,19 @@ if prompt := st.chat_input("Ask me something"):
 
                         chat_history.append(ModelResponse(parts=[TextPart(content=msg["text"])]))
 
+                {% if "mlflow" in plugins %}
+                with trace_chat(prompt) as span:
+                    result = asyncio.run(
+                        user_assistant_graph.run(
+                            inputs=StartNode(),
+                            state=initial_state,
+                            deps=manager.to_deps(
+                                message=prompt, language=st.session_state.default_language, chat_history=chat_history
+                            ),
+                        )
+                    )
+                    span.set_outputs(result)
+                {% else %}
                 result = asyncio.run(
                     user_assistant_graph.run(
                         inputs=StartNode(),
@@ -258,6 +271,7 @@ if prompt := st.chat_input("Ask me something"):
                         ),
                     )
                 )
+                {% endif %}
 
                 response = result
         except UsageLimitExceeded as e:

--- a/python-ai-kit/app/integrations/mlflow.py
+++ b/python-ai-kit/app/integrations/mlflow.py
@@ -1,4 +1,7 @@
 import inspect
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 
 import mlflow
 import pydantic_ai
@@ -25,9 +28,29 @@ def init_tracing() -> None:
     mlflow.set_experiment(settings.MLFLOW_EXPERIMENT)
     mlflow.pydantic_ai.autolog()
 
-    # autolog patches Agent.__init__ to inject instrument=True, a kwarg removed
-    # in pydantic-ai v2 — every Agent(...) would raise TypeError. Undo that
-    # patch and use v2's global switch, which has the same effect.
     pydantic_ai.Agent.__init__ = inspect.unwrap(pydantic_ai.Agent.__init__)
     pydantic_ai.Agent.instrument_all()
- 
+
+
+class _NoopSpan:
+    """Stands in for a live span when tracing is disabled."""
+
+    def set_outputs(self, outputs: Any) -> None:
+        pass
+
+
+@contextmanager
+def trace_chat(message: str) -> Iterator[Any]:
+    """Parent span grouping all agent runs of one request into a single trace.
+
+    Records the user message as the trace request; call ``set_outputs`` on the
+    yielded span to record the response. Without a parent span, every
+    Agent.run() inside the workflow graph becomes its own root span, so one
+    chat request shows up as several separate traces.
+    """
+    if not settings.MLFLOW_TRACING_ENABLED:
+        yield _NoopSpan()
+        return
+    with mlflow.start_span("chat", span_type="CHAIN") as span:
+        span.set_inputs({"message": message})
+        yield span

--- a/python-ai-kit/app/integrations/mlflow.py
+++ b/python-ai-kit/app/integrations/mlflow.py
@@ -1,0 +1,14 @@
+
+import mlflow
+
+from app.config import settings
+
+
+def init_tracing() -> None:
+    """Enable MLflow tracing when configured."""
+    if not settings.MLFLOW_TRACING_ENABLED:
+        return
+
+    mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
+    mlflow.set_experiment(settings.MLFLOW_EXPERIMENT)
+    mlflow.pydantic_ai.autolog()

--- a/python-ai-kit/app/integrations/mlflow.py
+++ b/python-ai-kit/app/integrations/mlflow.py
@@ -1,5 +1,8 @@
+import inspect
 
 import mlflow
+import pydantic_ai
+import pydantic_ai.mcp
 
 from app.config import settings
 
@@ -9,6 +12,22 @@ def init_tracing() -> None:
     if not settings.MLFLOW_TRACING_ENABLED:
         return
 
+    # mlflow (<= 3.14) instruments pydantic-ai v1; bridge the v2 API differences
+    # below. Drop both workarounds once mlflow supports pydantic-ai v2 natively.
+
+    # v1's MCPServer became MCPToolset in v2 (same call_tool/list_tools
+    # interface). Alias it so MCP tool calls are traced and span types resolve
+    # to LLM/AGENT/TOOL instead of UNKNOWN.
+    if not hasattr(pydantic_ai.mcp, "MCPServer"):
+        pydantic_ai.mcp.MCPServer = pydantic_ai.mcp.MCPToolset  # ty: ignore[unresolved-attribute]
+
     mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
     mlflow.set_experiment(settings.MLFLOW_EXPERIMENT)
     mlflow.pydantic_ai.autolog()
+
+    # autolog patches Agent.__init__ to inject instrument=True, a kwarg removed
+    # in pydantic-ai v2 — every Agent(...) would raise TypeError. Undo that
+    # patch and use v2's global switch, which has the same effect.
+    pydantic_ai.Agent.__init__ = inspect.unwrap(pydantic_ai.Agent.__init__)
+    pydantic_ai.Agent.instrument_all()
+ 

--- a/python-ai-kit/app/main.py.jinja
+++ b/python-ai-kit/app/main.py.jinja
@@ -24,6 +24,9 @@ from app.database import engine
 {% if "celery" in plugins %}
 from app.integrations.celery import create_celery
 {% endif %}
+{% if "mlflow" in plugins %}
+from app.integrations.mlflow import init_tracing
+{% endif %}
 {% if "sentry" in plugins %}
 from app.integrations.sentry import init_sentry
 {% endif %}
@@ -51,6 +54,9 @@ celery_app = create_celery()
 {% endif %}
 {% if "sentry" in plugins %}
 init_sentry()
+{% endif %}
+{% if "mlflow" in plugins %}
+init_tracing()
 {% endif %}
 
 add_cors_middleware(api)

--- a/python-ai-kit/config/.env.example.jinja
+++ b/python-ai-kit/config/.env.example.jinja
@@ -28,3 +28,12 @@ SQLADMIN_PASSWORD=password
 SQLADMIN_SECRET_KEY=sqladmin_secret
 SQLADMIN_TOKEN_TTL=3600
 {% endif %}
+
+{% if "mlflow" in plugins %}
+
+#--- MLflow ---#
+MLFLOW_TRACING_ENABLED=False
+MLFLOW_TRACKING_URI="http://localhost:5000"
+MLFLOW_EXPERIMENT=agent
+
+{% endif %}

--- a/python-ai-kit/config/.env.example.jinja
+++ b/python-ai-kit/config/.env.example.jinja
@@ -33,7 +33,8 @@ SQLADMIN_TOKEN_TTL=3600
 
 #--- MLflow ---#
 MLFLOW_TRACING_ENABLED=False
-MLFLOW_TRACKING_URI="http://localhost:5000"
+# outside docker compose (e.g. `uv run fastapi dev`) use http://localhost:5000
+MLFLOW_TRACKING_URI="http://mlflow:5000"
 MLFLOW_EXPERIMENT=agent
 
 {% endif %}

--- a/python-ai-kit/docker-compose.yml.jinja
+++ b/python-ai-kit/docker-compose.yml.jinja
@@ -39,6 +39,7 @@ services:
       - /root_project/.venv
     restart: on-failure
 
+  {% if "celery" in plugins %}
   celery-worker:
     container_name: celery-worker__{{project_name}}
     build: *shared-build
@@ -88,7 +89,29 @@ services:
     image: redis:8
     volumes:
       - redis_data:/var/lib/redis/data
+  {% endif %}
+
+  {% if "mlflow" in plugins %}
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v3.14.0-full
+    container_name: mlflow__{{project_name}}
+    entrypoint: ["sh", "/entrypoint.sh"]
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./docker/mlflow/ensure_db.py:/ensure_db.py:ro
+      - ./docker/mlflow/entrypoint.sh:/entrypoint.sh:ro
+      - mlflow_artifacts:/mlflow-artifacts
+    depends_on:
+      db:
+        condition: service_healthy
+  {% endif %}
 
 volumes:
   postgres_data:
+  {% if "celery" in plugins %}
   redis_data:
+  {% endif %}
+  {% if "mlflow" in plugins %}
+  mlflow_artifacts:
+  {% endif %}

--- a/python-ai-kit/docker-compose.yml.jinja
+++ b/python-ai-kit/docker-compose.yml.jinja
@@ -115,3 +115,4 @@ volumes:
   {% if "mlflow" in plugins %}
   mlflow_artifacts:
   {% endif %}
+  

--- a/python-ai-kit/docker/mlflow/ensure_db.py
+++ b/python-ai-kit/docker/mlflow/ensure_db.py
@@ -1,0 +1,36 @@
+"""Create the MLflow database if it does not exist yet.
+
+Runs inside the mlflow container (see docker-compose.yml), where psycopg2
+ships with the ghcr.io/mlflow/mlflow:*-full image.
+"""
+
+import os
+
+import psycopg2  # ty: ignore[unresolved-import]
+from psycopg2 import sql  # ty: ignore[unresolved-import]
+
+
+def main() -> None:
+    db_name = os.environ["MLFLOW_DB_NAME"]
+    conn = psycopg2.connect(
+        host=os.environ["PGHOST"],
+        port=os.environ["PGPORT"],
+        user=os.environ["PGUSER"],
+        password=os.environ["PGPASSWORD"],
+        dbname="postgres",
+    )
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (db_name,))
+            if cur.fetchone():
+                print(f"Database '{db_name}' already exists")
+                return
+            cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
+            print(f"Created database '{db_name}'")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python-ai-kit/docker/mlflow/entrypoint.sh.jinja
+++ b/python-ai-kit/docker/mlflow/entrypoint.sh.jinja
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+export PGHOST="${PGHOST:-db}"
+export PGPORT="${PGPORT:-5432}"
+export PGUSER="${PGUSER:-{{project_name}}}"
+export PGPASSWORD="${PGPASSWORD:-{{project_name}}}"
+export MLFLOW_DB_NAME="${MLFLOW_DB_NAME:-mlflow}"
+export MLFLOW_SERVER_ALLOWED_HOSTS="${MLFLOW_SERVER_ALLOWED_HOSTS:-mlflow:5000,localhost:5000,127.0.0.1:5000}"
+
+python /ensure_db.py
+
+exec mlflow server \
+    --host 0.0.0.0 \
+    --port 5000 \
+    --backend-store-uri "postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${MLFLOW_DB_NAME}" \
+    --artifacts-destination /mlflow-artifacts

--- a/python-ai-kit/pyproject.toml.jinja
+++ b/python-ai-kit/pyproject.toml.jinja
@@ -36,6 +36,9 @@ dependencies = [
     {% if "sentry" in plugins %}
     "sentry-sdk[fastapi]>=2.42.1",
     {% endif %}
+    {% if "mlflow" in plugins %}
+    "mlflow>=3.14.0",
+    {% endif %}
 ]
 
 [dependency-groups]


### PR DESCRIPTION
- New **MLflow plugin** for `agent` projects: `mlflow` dependency + `app/integrations/mlflow.py` with tracing setup, gated by `MLFLOW_TRACING_ENABLED` (off by default)
- Agent projects now ship `docker-compose.yml` / `Dockerfile` (fixes dead `just run`/`just up`) with a new **mlflow service** — official `ghcr.io/mlflow/mlflow:v3.14.0-full` image, Postgres backend in an auto-created separate `mlflow` database, artifacts on a named volume
- Celery/Redis compose services are now rendered only when the celery plugin is selected
- Tracing covers both the API (`/chat`) and the Streamlit GUI; all agent runs of one request are grouped into a single trace (`chat` CHAIN root span with request/response previews)
- Compatibility bridge for **pydantic-ai v2** (mlflow ≤ 3.14 instruments the v1 API): `MCPServer → MCPToolset` alias + `Agent.instrument_all()` instead of the broken `instrument=True` injection — to be removed once mlflow/mlflow#22945 lands
- Docs: "Running with Docker" + "Tracing with MLflow" sections in the agent README, AGENTS.md and `.env.example` updates