### PR TITLE
Add sync db sessionmaker for Celery tasks

### DIFF
--- a/python-ai-kit/AGENTS.md.jinja
+++ b/python-ai-kit/AGENTS.md.jinja
@@ -27,7 +27,7 @@ Read these before touching anything. They override every other section.
 - **Never commit secrets.** `config/.env`, `MASTER_KEY`, API keys{% if project_type in ["api-monolith", "api-microservice", "agent"] %}, DB credentials{% endif %} — scan the diff every time. Only `config/.env.example` belongs in git.
 - **Type hints on every function.** PEP 604 (`str | None`), not `Optional[str]`. All imports at module level — never inside functions.
 {% if project_type in ["api-monolith", "api-microservice", "agent"] %}
-- **The DB layer is async.** The session is `AsyncSession` (`AsyncDbSession` dependency). Every repository and DB-touching service method is `async def`; every call down the chain (route → service → repo) is `await`ed. Build queries with SQLAlchemy 2.0 style — `select(...)` + `await db_session.execute(stmt)` then `.scalar_one_or_none()` / `.scalars().all()`, never the legacy `db_session.query(...)`. Outside routes (scripts, background jobs) get a session from `adb_session_ctx`.
+- **The DB layer is async{% if "celery" in plugins %} — except Celery tasks{% endif %}.** The session is `AsyncSession` (`AsyncDbSession` dependency). Every repository and DB-touching service method is `async def`; every call down the chain (route → service → repo) is `await`ed. Build queries with SQLAlchemy 2.0 style — `select(...)` + `await db_session.execute(stmt)` then `.scalar_one_or_none()` / `.scalars().all()`, never the legacy `db_session.query(...)`. Outside routes (scripts, background jobs) get a session from `adb_session_ctx`.{% if "celery" in plugins %} **Celery is the one sync exception** — workers are synchronous, so tasks use the sync session (`db_session_ctx` / `SyncSessionLocal`). See [Celery DB access](#celery-db-access).{% endif %}
 {% endif %}
 {% if project_type in ["api-monolith", "api-microservice"] %}
 - **Respect layer boundaries.** Routes → services → repositories. Services own business logic and error translation. Repositories do DB I/O only. See [Layer contracts](#layer-contracts).
@@ -148,6 +148,31 @@ Use `examples/pdf-agent/` as the worked reference — it shows the full extensio
 2. Export it from `app/integrations/celery/tasks/__init__.py`.
 3. Periodic tasks: add an entry to `beat_schedule` in `app/integrations/celery/core.py`.
 4. The Celery app instance is `celery_app` in `app/main.py` (created by `create_celery()`); worker/beat/flower start scripts live in `scripts/start/`.
+{% if project_type in ["api-monolith", "api-microservice", "agent"] %}
+5. DB access: **default to the sync session** — see [Celery DB access](#celery-db-access).
+
+### <a id="celery-db-access"></a>Celery DB access (sync-first)
+
+Celery workers are synchronous processes. Tasks are the **only** place in this codebase that touch the DB synchronously. Reference: `app/integrations/celery/tasks/dummy_task.py` (`sync_db_task`, `async_wrapped_task`).
+
+**The rule: if you can do the work with the sync session, do it. If you must reuse existing async code, wrap it with `asyncio.run`.**
+
+1. **Preferred — sync session.** Open `db_session_ctx()` (sync context manager over `SyncSessionLocal`) and use SQLAlchemy 2.0 style with **no** `await`: `session.execute(select(...))` then `.scalar_one_or_none()` / `.scalars().all()`. Commit with `session.commit()` when you write.
+   ```python
+   with db_session_ctx() as session:
+       result = session.execute(select(1)).scalar_one()
+   ```
+2. **Fallback — wrap async.** When the logic already lives in an async service/repository and rewriting it in sync isn't worth it, drive the coroutine with `asyncio.run(...)` and open the session with `adb_session_ctx()` (never the FastAPI-injected `AsyncDbSession`). `asyncio.run` spins up a fresh event loop per call — correct for a sync worker with no running loop.
+   ```python
+   async def _run() -> int:
+       async with adb_session_ctx() as session:
+           result = await session.execute(select(1))
+           return result.scalar_one()
+
+   asyncio.run(_run())
+   ```
+3. Do **not** reach for `asyncio.run` by default — a sync query is simpler, cheaper, and has no event-loop overhead. Reserve wrapping for genuine async-code reuse.
+{% endif %}
 {% endif %}
 
 ---
@@ -294,8 +319,9 @@ Model new code on the canonical files below — they are the reference implement
 | Schemas (Read/Create/Update) | `app/schemas/user.py` |
 | Schema exports | `app/schemas/__init__.py` |
 | Custom column types | `app/mappings.py` (`PrimaryKey`, `Unique`, `UniqueIndex`, `Indexed`, `str_10/50/100/255`, `email`, `numeric_*`, `datetime_tz`, `OneToMany`, `ManyToOne`, `FKUser`) |
-| Session dependency | `app/database.py` (`AsyncDbSession` — annotated FastAPI dependency) |
-| Error handling | `app/utils/exceptions.py` (`handle_exceptions`, `handle_exception`, `ResourceNotFoundError`) |
+| Session dependency (async) | `app/database.py` (`AsyncDbSession` — annotated FastAPI dependency; `adb_session_ctx` outside routes) |
+{% if "celery" in plugins %}| Session (sync, Celery only) | `app/database.py` (`db_session_ctx` / `SyncSessionLocal`); example in `app/integrations/celery/tasks/dummy_task.py` |
+{% endif %}| Error handling | `app/utils/exceptions.py` (`handle_exceptions`, `handle_exception`, `ResourceNotFoundError`) |
 
 The scaffold ships `app/api/routes/v1/user.py`, `app/services/user.py` and `app/repositories/user.py` as **empty stubs** — they mark where each layer lives but contain no example code. When implementing them (or any new resource), follow this shape:
 
@@ -344,8 +370,9 @@ Then mount `router` on `head_router` in `app/api/__init__.py` with a prefix and 
 | Service mixin | `app/user/services/activity_mixin.py` |
 | HATEOAS responses | `app/utils/api_utils.py` (`format_response`), `app/utils/hateoas.py` |
 | Custom column types | `app/mappings.py` (`PrimaryKey`, `Unique`, `UniqueIndex`, `Indexed`, `str_10/50/100/255`, `email`, `numeric_*`, `datetime_tz`, `OneToMany`, `ManyToOne`, `FKUser`) |
-| Session dependency | `app/database.py` (`AsyncDbSession` — annotated FastAPI dependency) |
-| Error handling | `app/utils/exceptions.py` (`handle_exceptions`, `handle_exception`, `ResourceNotFoundError`) |
+| Session dependency (async) | `app/database.py` (`AsyncDbSession` — annotated FastAPI dependency; `adb_session_ctx` outside routes) |
+{% if "celery" in plugins %}| Session (sync, Celery only) | `app/database.py` (`db_session_ctx` / `SyncSessionLocal`); example in `app/integrations/celery/tasks/dummy_task.py` |
+{% endif %}| Error handling | `app/utils/exceptions.py` (`handle_exceptions`, `handle_exception`, `ResourceNotFoundError`) |
 | Router registration | `app/api.py` (`head_router`) |
 
 Services are exposed as module-level singletons (`user_service`) and imported directly by routes — follow that pattern for new modules.
@@ -367,6 +394,8 @@ Services are exposed as module-level singletons (`user_service`) and imported di
 | HTTP entrypoint | `app/api/routes/v1/chat.py` |
 | Full custom-workflow example | `examples/pdf-agent/` |
 | Model / column types / session | `app/models/`, `app/mappings.py`, `app/database.py` (`AsyncDbSession`) |
+{% if "celery" in plugins %}| Session (sync, Celery only) | `app/database.py` (`db_session_ctx` / `SyncSessionLocal`); example in `app/integrations/celery/tasks/dummy_task.py` |
+{% endif %}
 {% elif project_type == "mcp-server" %}
 | Pattern | Canonical file |
 |---------|----------------|
@@ -639,7 +668,8 @@ These are pointed reminders for the moment you're doing the thing. They repeat r
 - [ ] Periodic schedule added to `beat_schedule` in `core.py` if needed.
 - [ ] Task is idempotent or guarded — Celery retries can re-run it.
 - [ ] Failures are logged with context, not silently swallowed.
-{% endif %}
+{% if project_type in ["api-monolith", "api-microservice", "agent"] %}- [ ] DB access uses the **sync** session (`db_session_ctx`) by default; `asyncio.run` + `adb_session_ctx` only to reuse existing async code. **Not** `AsyncDbSession` (that's the FastAPI dependency).
+{% endif %}{% endif %}
 
 ---
 

--- a/python-ai-kit/app/database.py
+++ b/python-ai-kit/app/database.py
@@ -1,12 +1,10 @@
-from contextlib import asynccontextmanager
-from typing import Annotated, AsyncIterator
+from contextlib import asynccontextmanager, contextmanager
+from typing import Annotated, AsyncIterator, Iterator, TypedDict
 from uuid import UUID
 
-from app.config import settings
-from app.utils.mappings_meta import AutoRelMeta
 from fastapi import Depends
 from sqlalchemy import UUID as SQL_UUID
-from sqlalchemy import Text, inspect
+from sqlalchemy import Engine, Text, create_engine, inspect
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -15,8 +13,13 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.orm import (
     DeclarativeBase,
+    Session,
     declared_attr,
+    sessionmaker,
 )
+
+from app.config import settings
+from app.utils.mappings_meta import AutoRelMeta
 
 
 class BaseDbModel(DeclarativeBase, metaclass=AutoRelMeta):
@@ -30,9 +33,7 @@ class BaseDbModel(DeclarativeBase, metaclass=AutoRelMeta):
 
     def __repr__(self) -> str:
         mapper = inspect(self.__class__)
-        fields = [
-            f"{col.key}={repr(getattr(self, col.key, None))}" for col in mapper.columns
-        ]
+        fields = [f"{col.key}={repr(getattr(self, col.key, None))}" for col in mapper.columns]
         return f"<{self.__class__.__name__}({', '.join(fields)})>"
 
     type_annotation_map = {
@@ -41,23 +42,37 @@ class BaseDbModel(DeclarativeBase, metaclass=AutoRelMeta):
     }
 
 
-async_engine = create_async_engine(
-    settings.db_async_uri,
-    pool_pre_ping=True,
-    pool_size=20,
-    max_overflow=30,
-    pool_timeout=30,
-    pool_recycle=3600,
-)
+# TODO: export engine config to global settings
+class DbEngineConfig(TypedDict):
+    pool_pre_ping: bool
+    pool_size: int
+    max_overflow: int
+    pool_timeout: int
+    pool_recycle: int
+
+
+db_engine_config: DbEngineConfig = {
+    "pool_pre_ping": True,
+    "pool_size": 20,
+    "max_overflow": 30,
+    "pool_timeout": 30,
+    "pool_recycle": 3600,
+}
+
+async_engine = create_async_engine(settings.db_async_uri, **db_engine_config)
+sync_engine = create_engine(settings.db_uri, **db_engine_config)
 
 
 def _prepare_async_sessionmaker(engine: AsyncEngine) -> async_sessionmaker:
-    return async_sessionmaker(
-        autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
-    )
+    return async_sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
+
+
+def _prepare_sessionmaker(engine: Engine) -> sessionmaker:
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
 
 
 AsyncSessionLocal = _prepare_async_sessionmaker(async_engine)
+SyncSessionLocal = _prepare_sessionmaker(sync_engine)
 
 
 async def _get_async_db_dependency() -> AsyncIterator[AsyncSession]:
@@ -71,5 +86,19 @@ async def _get_async_db_dependency() -> AsyncIterator[AsyncSession]:
         await session.close()
 
 
+def _get_db_dependency() -> Iterator[Session]:
+    session = SyncSessionLocal()
+    try:
+        yield session
+    except Exception as exc:
+        session.rollback()
+        raise exc
+    finally:
+        session.close()
+
+
 adb_session_ctx = asynccontextmanager(_get_async_db_dependency)
 AsyncDbSession = Annotated[AsyncSession, Depends(_get_async_db_dependency)]
+
+db_session_ctx = contextmanager(_get_db_dependency)
+SyncDbSession = Annotated[Session, Depends(_get_db_dependency)]

--- a/python-ai-kit/app/integrations/celery/tasks/__init__.py
+++ b/python-ai-kit/app/integrations/celery/tasks/__init__.py
@@ -1,3 +1,3 @@
-from .dummy_task import dummy_task
+from .dummy_task import async_wrapped_task, dummy_task, sync_db_task
 
-__all__ = ["dummy_task"]
+__all__ = ["async_wrapped_task", "dummy_task", "sync_db_task"]

--- a/python-ai-kit/app/integrations/celery/tasks/dummy_task.py
+++ b/python-ai-kit/app/integrations/celery/tasks/dummy_task.py
@@ -1,5 +1,9 @@
+import asyncio
 import logging
 
+from sqlalchemy import select
+
+from app.database import adb_session_ctx, db_session_ctx
 from celery import shared_task
 
 log = logging.getLogger(__name__)
@@ -8,3 +12,39 @@ log = logging.getLogger(__name__)
 @shared_task
 def dummy_task() -> None:
     log.info("Task performed")
+
+
+@shared_task
+def sync_db_task() -> int:
+    """PREFERRED pattern — plain sync session, no event loop.
+
+    Use `db_session_ctx()` (sync context manager over `SyncSessionLocal`) and
+    build queries with SQLAlchemy 2.0 style: `select(...)` + `session.execute(...)`.
+    No `await` anywhere. Commit with `session.commit()` when you write.
+    """
+    with db_session_ctx() as session:
+        result = session.execute(select(1)).scalar_one()
+        log.info("sync_db_task: db ping -> %s", result)
+        return result
+
+
+@shared_task
+def async_wrapped_task() -> int:
+    """FALLBACK pattern — reuse async services/repositories from a sync task.
+
+    When the logic already lives in async code and duplicating it in sync is not
+    worth it, drive the coroutine with `asyncio.run(...)`. Open the async session
+    with `adb_session_ctx()` (NOT the FastAPI-injected `AsyncDbSession`).
+
+    `asyncio.run` creates and tears down a fresh event loop per call — correct
+    for a sync Celery worker, which has no running loop of its own.
+    """
+
+    async def _run() -> int:
+        async with adb_session_ctx() as session:
+            result = await session.execute(select(1))
+            return result.scalar_one()
+
+    ping = asyncio.run(_run())
+    log.info("async_wrapped_task: db ping -> %s", ping)
+    return ping


### PR DESCRIPTION
Related issue: https://github.com/the-momentum/python-ai-kit/issues/121 

In my previous MR (https://github.com/the-momentum/python-ai-kit/pull/108) we have migrated from sync to async SQLAlchemy sessions. That fits the API layer very well (FastAPI is async-first), but async sessions may cause problems in a purely synchronous context — namely inside Celery tasks. For that specific case I propose using sync db sessions, since running anything async inside Celery is famously painful.

This MR adds a sync db sessionmaker and lays out how to handle database operations inside Celery tasks. Rule of thumb:
  - use **async** db sessions in the API layer;
  - use **sync** db sessions inside Celery tasks. If that's not possible (e.g. you need to reuse a service exposing async methods), wrap the call with `asyncio.run`.

In this MR:
  - added a sync db sessionmaker in `app/database.py`;
  - updated the docs (`AGENTS.md`) to describe the approach above;
  - added example tasks showing how to perform db operations (`app/integrations/celery/tasks/dummy_task.py`).